### PR TITLE
Update the posthog-js dependency to the latest and keep it up to date

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-    "posthog-js": "1.16.0"
+    "posthog-js": "^1.38.0"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17 || ^18"


### PR DESCRIPTION
Currently the posthog-js dependency is a few versions behind.

This updates it to the latest version and uses `^` to keep it up to date.

(Keeping as a draft while I verify this won't break anything)